### PR TITLE
Removes reference to gke-ssd StorageClass

### DIFF
--- a/cloudflow-environment/templates/strimzi-kafka-cluster.yaml
+++ b/cloudflow-environment/templates/strimzi-kafka-cluster.yaml
@@ -13,18 +13,6 @@
 # limitations under the License.
 
 
-{{ if eq .Values.kafka.mode "CloudflowManaged" }}
-{{ if .Values.tags.targetGke }}
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  name: gke-ssd
-  labels: {{ include "operator.labels" . | indent 4 }}
-provisioner: kubernetes.io/gce-pd
-parameters:
-  type: pd-ssd
----
-{{ end }}
 apiVersion: kafka.strimzi.io/v1beta1
 kind: Kafka
 metadata:
@@ -50,8 +38,8 @@ spec:
       type: persistent-claim
       size: {{ .Values.kafka.strimzi.kafka.persistentVolumeClaimSize }}
       deleteClaim: {{ .Values.kafka.strimzi.deletePersistentVolumeClaimsOnDelete }}
-      {{ if or .Values.defaultPersistentStorageClass .Values.kafka.strimzi.kafka.persistentStorageClass }}
-      class: {{ default  .Values.defaultPersistentStorageClass .Values.kafka.strimzi.kafka.persistentStorageClass }}
+      {{ if .Values.kafka.strimzi.kafka.persistentStorageClass }}
+      class: {{ default .Values.kafka.strimzi.kafka.persistentStorageClass }}
       {{ end }}
     {{ if .Values.kafka.strimzi.useDedicatedNodes }}
     tolerations:
@@ -180,8 +168,8 @@ spec:
       type: persistent-claim
       size: {{ .Values.kafka.strimzi.zookeeper.persistentVolumeClaimSize }}
       deleteClaim: {{ .Values.kafka.strimzi.deletePersistentVolumeClaimsOnDelete }}
-      {{ if or .Values.defaultPersistentStorageClass .Values.kafka.strimzi.zookeeper.persistentStorageClass }}
-      class: {{ default  .Values.defaultPersistentStorageClass .Values.kafka.strimzi.zookeeper.persistentStorageClass }}      
+      {{ if .Values.kafka.strimzi.zookeeper.persistentStorageClass }}
+      class: {{ .Values.kafka.strimzi.zookeeper.persistentStorageClass }}      
       {{ end }}
     {{ if .Values.kafka.strimzi.useDedicatedNodes }}
     tolerations:

--- a/common/gke-values.yaml
+++ b/common/gke-values.yaml
@@ -18,14 +18,11 @@ tags:
   targetMinishift: false
 
 
-defaultPersistentStorageClass: gke-ssd
-
 kafka:
   strimzi:
     useDedicatedNodes: true
     kafka:
      persistentVolumeClaimSize: 100Gi
-     persistentStorageClass: gke-ssd
      resources:
         requests:
           memory: "5Gi"
@@ -33,7 +30,6 @@ kafka:
           memory: "9Gi"
     zookeeper:
       persistentVolumeClaimSize: 10Gi
-      persistentStorageClass: gke-ssd
       resources:
         requests:
           memory: "1Gi"
@@ -53,4 +49,3 @@ operator:
   sparkExecutor:
     requestsCpu: "1"
     requestsMemory: "2G"
-  persistentStorageClass: "nfs-client"


### PR DESCRIPTION
Removes reference to `gke-ssd` StorageClass.

Removed the StorageClass definition, with the user selected storage classes, this is no more used.
Also removed the set values for storage classes in `gke-values.yaml`. These values are always overwritten by user selected ones.