### PR TITLE
Update cluster version

### DIFF
--- a/gke-create-cluster.sh
+++ b/gke-create-cluster.sh
@@ -30,7 +30,7 @@ CLUSTER_NAME=$1
 # https://cloud.google.com/kubernetes-engine/versioning-and-upgrades#versions_available_for_new_cluster_masters
 # use command `gcloud container get-server-config` to find latest supported master GKE cluster version
 gcloud container clusters create $CLUSTER_NAME \
-  --cluster-version 1.13.11-gke.9 \
+  --cluster-version 1.13.11-gke.14  \
   --image-type cos \
   --machine-type n1-standard-4 \
   --num-nodes 3 \
@@ -52,7 +52,7 @@ gcloud beta container node-pools create kafka-pool-0 \
 
 ## Wait for clusters to come up
 echo "Waiting for cluster to become stable before continuing with the installation....."
-gcloud compute instance-groups managed list | grep gke-$CLUSTER_NAME | awk '/'$my_name'/ {print $1}' | while read -r line ; do 
+gcloud compute instance-groups managed list | grep gke-$CLUSTER_NAME | awk '/'$my_name'/ {print $1}' | while read -r line ; do
   gcloud compute instance-groups managed wait-until-stable $line
 done
 


### PR DESCRIPTION
Cluster creation fails on GKE.
```
This will enable the autorepair feature for nodes. Please see https://cloud.google.com/kubernetes-engine/docs/node-auto-repair for more information on node autorepairs.
ERROR: (gcloud.container.clusters.create) ResponseError: code=400, message=Master version "1.13.11-gke.9" is unsupported.
```
Google has updated their cluster versions due to the kernel panic issue: https://cloud.google.com/kubernetes-engine/docs/release-notes

New version works:
```
WARNING: Your Pod address range (`--cluster-ipv4-cidr`) can accommodate at most 1008 node(s). 
This will enable the autorepair feature for nodes. Please see https://cloud.google.com/kubernetes-engine/docs/node-auto-repair for more information on node autorepairs.
Creating cluster test-oss in europe-west1-b... Cluster is being health-checked (master is healthy)...done.                                                                  
....
kubeconfig entry generated for test-oss.
NAME      LOCATION        MASTER_VERSION  MASTER_IP     MACHINE_TYPE   NODE_VERSION    NUM_NODES  STATUS
test-oss  europe-west1-b  1.13.11-gke.14  34.77.159.35  n1-standard-4  1.13.11-gke.14  3          RUNNING
```