### PR TITLE
Fix strimzi yaml 

### DIFF
--- a/cloudflow-environment/templates/strimzi-kafka-cluster.yaml
+++ b/cloudflow-environment/templates/strimzi-kafka-cluster.yaml
@@ -169,7 +169,7 @@ spec:
       size: {{ .Values.kafka.strimzi.zookeeper.persistentVolumeClaimSize }}
       deleteClaim: {{ .Values.kafka.strimzi.deletePersistentVolumeClaimsOnDelete }}
       {{ if .Values.kafka.strimzi.zookeeper.persistentStorageClass }}
-      class: {{ .Values.kafka.strimzi.zookeeper.persistentStorageClass }}      
+      class: {{ .Values.kafka.strimzi.zookeeper.persistentStorageClass }}
       {{ end }}
     {{ if .Values.kafka.strimzi.useDedicatedNodes }}
     tolerations:
@@ -220,4 +220,3 @@ spec:
     topicOperator:
       resources:
 {{ toYaml .Values.kafka.strimzi.entityOperator.topicOperator.resources | indent 8 }}
-{{ end }}


### PR DESCRIPTION
Removes tag that broke the installer. Currently process stops with error:
```
Installing Cloudflow
Error: parse error in "cloudflow-environment/templates/strimzi-kafka-cluster.yaml": template: cloudflow-environment/templates/strimzi-kafka-cluster.yaml:223: unexpected {{end}}
Installation failed
Release "cloudflow" does not exist. Installing it now.
```
Top level if statement was removed with this commit: https://github.com/lightbend/cloudflow-installer/commit/e5e4f8f429b5c53045a05351c31da3a67c8865d3 but its related ```{{end}}``` was not removed.