### PR TITLE
Add back if for Kafka install type

### DIFF
--- a/cloudflow-environment/templates/strimzi-kafka-cluster.yaml
+++ b/cloudflow-environment/templates/strimzi-kafka-cluster.yaml
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 
+{{ if eq .Values.kafka.mode "CloudflowManaged" }}
 apiVersion: kafka.strimzi.io/v1beta1
 kind: Kafka
 metadata:
@@ -220,3 +221,4 @@ spec:
     topicOperator:
       resources:
 {{ toYaml .Values.kafka.strimzi.entityOperator.topicOperator.resources | indent 8 }}
+{{ end }}


### PR DESCRIPTION

### What changes were proposed in this pull request?
Fixes a problem in PR #2. An extra `if` statement had been removed.

### Why are the changes needed?
Without this change, the configuration for `CloudflowManaged` will always included

### Does this PR introduce any user-facing change?
No, fixing a bug.

### How was this patch tested?
The helm chart was run to install cloudflow